### PR TITLE
[feat] 비밀번호 변경 시 refresh token도 만료 시키는 기능 구현

### DIFF
--- a/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/controller/UserController.java
+++ b/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/controller/UserController.java
@@ -55,12 +55,12 @@ public class UserController {
     }
 
     @PatchMapping("/me/password")
-    public ResponseEntity<Boolean> changeUserPassword(
+    public ResponseEntity<String> changeUserPassword(
             @RequestBody ChangePasswordRequest request,
             @AuthenticationPrincipal UUID userId
     ) {
-        Boolean updated = userService.changeUserPassword(userId, request);
-        return ResponseEntity.ok(updated);
+        String refreshToken = userService.changeUserPassword(userId, request);
+        return ResponseEntity.ok(refreshToken);
     }
 
     @PostMapping("/me/deactivate")

--- a/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/dto/ChangePasswordRequest.java
+++ b/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/dto/ChangePasswordRequest.java
@@ -8,4 +8,5 @@ import lombok.Setter;
 public class ChangePasswordRequest {
     private String password;
     private String newPassword;
+    private String refreshToken;
 }

--- a/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/service/UserService.java
+++ b/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/service/UserService.java
@@ -23,7 +23,7 @@ public interface UserService {
 
     public Boolean addNewPassword(UUID id, String rawPassword);
 
-    public Boolean changeUserPassword(UUID id, ChangePasswordRequest request);
+    public String changeUserPassword(UUID id, ChangePasswordRequest request);
 
     private String encodePassword(String rawPassword) {
         if (rawPassword == null || rawPassword.isEmpty()) {

--- a/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/service/UserServiceImpl.java
+++ b/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/service/UserServiceImpl.java
@@ -8,6 +8,7 @@ import ada.divercity.diverbook_server.entity.Password;
 import ada.divercity.diverbook_server.entity.User;
 import ada.divercity.diverbook_server.repository.PasswordRepository;
 import ada.divercity.diverbook_server.repository.UserRepository;
+import ada.divercity.diverbook_server.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -22,6 +23,7 @@ public class UserServiceImpl implements UserService {
     private final UserRepository userRepository;
     private final PasswordRepository passwordRepository;
     private final TokenBlackListServiceImpl tokenBlackListService;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public UserDto createUser(RegisterUserRequest request) {
         if (userRepository.findByUserName(request.getUserName()).isPresent()) {
@@ -118,7 +120,7 @@ public class UserServiceImpl implements UserService {
 
         return true;
     }
-    public Boolean changeUserPassword(UUID id, ChangePasswordRequest request) {
+    public String changeUserPassword(UUID id, ChangePasswordRequest request) {
         Password password = passwordRepository.findById(id).orElseThrow(() -> new RuntimeException("User not found"));
         BCryptPasswordEncoder encoder = new BCryptPasswordEncoder();
 
@@ -133,9 +135,11 @@ public class UserServiceImpl implements UserService {
         password.setPassword(encodePassword(request.getNewPassword()));
         tokenBlackListService.addTokenToBlackList(request.getRefreshToken());
 
+        String refreshToken = jwtTokenProvider.generateRefreshToken(password.getUserId().toString());
+
         passwordRepository.save(password);
 
-        return true;
+        return refreshToken;
     }
 
     private String encodePassword(String rawPassword) {

--- a/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/service/UserServiceImpl.java
+++ b/DiverBook_Server/src/main/java/ada/divercity/diverbook_server/service/UserServiceImpl.java
@@ -21,6 +21,7 @@ public class UserServiceImpl implements UserService {
 
     private final UserRepository userRepository;
     private final PasswordRepository passwordRepository;
+    private final TokenBlackListServiceImpl tokenBlackListService;
 
     public UserDto createUser(RegisterUserRequest request) {
         if (userRepository.findByUserName(request.getUserName()).isPresent()) {
@@ -130,6 +131,7 @@ public class UserServiceImpl implements UserService {
         }
 
         password.setPassword(encodePassword(request.getNewPassword()));
+        tokenBlackListService.addTokenToBlackList(request.getRefreshToken());
 
         passwordRepository.save(password);
 


### PR DESCRIPTION
## 🖥️ 작업 내역

> 구현 내용 및 작업 했던 내역을 적어주세요.
>
- [x] 비밀번호 변경 시 refresh token 만료시킴
- [x] 비밀번호 변경 시 refresh token 재발급

## 📌 PR 특이사항

> PR을 볼 때 팀원에게 알려야 할 특이사항을 알려주세요.
>
- ChangePasswordRequest DTO 변경
- /me/password/ ResponseEntity 변경 (Boolean -> String)

## 🗂️ 레퍼런스
- 참고한 자료
- 깃헙 위키 페이지
